### PR TITLE
Refactor: Update 'Account Age' format and reduce font size

### DIFF
--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1279,8 +1279,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    'Account age: $days days, $hours hours, $minutes minutes',
-                    style: Theme.of(context).textTheme.bodyMedium,
+                    'Account age: $days days, $hours hrs, $minutes mins',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize! - 1,
+                    ),
                   ),
                   const SizedBox(height: 4),
                   Row(

--- a/lib/screens/user_page.dart
+++ b/lib/screens/user_page.dart
@@ -519,8 +519,10 @@ class _UserPageState extends State<UserPage> {
               ),
               const SizedBox(height: 4),
               Text(
-                'Account age: $days days, $hours hours, $minutes minutes',
-                style: Theme.of(context).textTheme.bodyMedium,
+                'Account age: $days days, $hours hrs, $minutes mins',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize! - 1,
+                ),
               ),
               const SizedBox(height: 4),
               Row(


### PR DESCRIPTION
## Description
This PR addresses [Issue #9]by improving the formatting and visual appearance of the "Account Age" display across the app.

### Changes Implemented : 
Time Format Updated
-> Changed the display from:
           x days, y hours, z min to the more concise:  x days, y hrs, z mins

 -> Font Size Reduced :
    Decreased the font size of the "Account Age" text by 1 unit from the default bodyMedium, making the display more compact and subtle.

close #9 