### PR TITLE
Fix: Add proper spacing below progress bar in Book Statistics card on…

### DIFF
--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1080,7 +1080,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                         value: _totalBooks > 0 ? _totalPages / _totalBooks : 0,
                         backgroundColor: Colors.grey[200],
                       ),
-                      const SizedBox(height: 5),
+                      const SizedBox(height: 10),
                     ],
                   ),
                 ),


### PR DESCRIPTION
##  Summary
This PR resolves the issue where the progress bar in the 'Book Statistics' section of the profile page was too close to the bottom of the card. The vertical spacing below the progress bar now matches the left and right padding of the card, resulting in a more visually balanced layout.

## Details
- Increased the height of the `SizedBox` below the `LinearProgressIndicator` from 5 to 10 pixels.
- This change ensures the bottom spacing is consistent with the card’s horizontal padding, as requested in [Issue #7 ]


### Closes
Closes #7